### PR TITLE
Modified new refresh tokens creation - now when user tries to log in …

### DIFF
--- a/Back-end/app.js
+++ b/Back-end/app.js
@@ -20,12 +20,14 @@ const connectionSettings = {
 };
 
 app.use((req, res, next) => {
-  res.setHeader('Access-Control-Allow-Origin', `${process.env.FE_URI}`);
+  //res.setHeader('Access-Control-Allow-Origin', `${process.env.FE_URI}`);
+  res.setHeader('Access-Control-Allow-Origin', `http://localhost:3000`);
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept, Authorization, accesstoken, refreshtoken, user',
+    'Origin, X-Requested-With, Content-Type, Accept, Authorization, accessToken, refreshToken, user',
   );
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE');
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
   next();
 });
 

--- a/Back-end/controllers/auth-controller.js
+++ b/Back-end/controllers/auth-controller.js
@@ -2,8 +2,8 @@ import { CheckToken, RefreshAccessToken } from './tokens-controller';
 import Cookies from 'cookies';
 //Not working yet, need to find a way to work this out
 export const AuthoriseUser = async (req, res, next) => {
-  let accessToken = req.headers['accesstoken'];
-  const refreshToken = req.headers['refreshtoken'];
+  let accessToken = req.headers['accessToken'];
+  const refreshToken = req.headers['refreshToken'];
   const login = req.headers['user'];
   const user = { login: login };
   let accessTokenValid = await CheckToken(accessToken);

--- a/Back-end/controllers/tokens-controller.js
+++ b/Back-end/controllers/tokens-controller.js
@@ -54,11 +54,26 @@ export const CreateTokens = async (user) => {
   const accessToken = genereateToken(user);
   const refreshToken = jwt.sign(user, process.env.REFRESH_TOKEN_SECRET);
   const token = new Token({ name: user.login, refreshToken });
-  const tokens = { accessToken: accessToken, refreshToken: refreshToken };
-  try {
-    await token.save();
-  } catch (err) {
-    console.log(err);
+  const checkToken = Token.find({ name: user.login });
+  if (!checkToken) {
+    try {
+      await token.save();
+    } catch (err) {
+      console.log(err);
+    }
+  } else {
+    try {
+      await Token.findOneAndUpdate(
+        { name: user.login },
+        { refreshToken: refreshToken },
+        { new: true, useFindAndModify: false },
+      );
+    } catch (err) {
+      console.log(err);
+    }
   }
+
+  const tokens = { accessToken: accessToken, refreshToken: refreshToken };
+
   return tokens;
 };

--- a/Back-end/controllers/users-controller.js
+++ b/Back-end/controllers/users-controller.js
@@ -70,7 +70,7 @@ export const userLogin = async (req, res, next) => {
       const cookies = new Cookies(req, res);
       cookies.set('accessToken', tokens.accessToken);
       cookies.set('refreshToken', tokens.refreshToken);
-      cookies.set('user', checkUser.login);
+      cookies.set('user', checkUser.login, { httpOnly: false });
       res.send({
         message: 'Logging successful!',
       });


### PR DESCRIPTION
…server sends one query to check if refresh token already exists for this user. If not - new token is created, if yes - old token is replaced with the new one in database. Also both tokens are sent back in a httpOnly cookie (unavailable to back end). User's login is also beeing sent in a cookie without httpOnly option and is available to front end for front end authentication.