### PR TITLE
Fixed error catching while updating title and description of task. Be…

### DIFF
--- a/Back-end/controllers/tasks-controller.js
+++ b/Back-end/controllers/tasks-controller.js
@@ -90,6 +90,10 @@ export const updateTitle = async (req, res, next) => {
 
   const title = req.body;
 
+  if (!title.title) {
+    return res.status(500).json({ message: 'No title provided!' });
+  }
+
   try {
     await Task.findByIdAndUpdate(id, title, { useFindAndModify: false });
   } catch (error) {
@@ -106,6 +110,12 @@ export const updateDescription = async (req, res, next) => {
   const id = req.params.tid;
 
   const description = req.body;
+
+  console.log(description);
+
+  if (!description.description) {
+    return res.status(500).json({ message: 'No description provided!' });
+  }
 
   try {
     await Task.findByIdAndUpdate(id, description, { useFindAndModify: false });


### PR DESCRIPTION
…fore no error appeared if incorect data was provided (misspelled key, eg. 'descriptionS' instead of 'description') and the data was not updated with no feedback why. Now everything works properly.